### PR TITLE
Improve readability

### DIFF
--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -28,7 +28,7 @@ body{
 
 a{
   text-decoration: none;
-  color:inherit;
+  color: var(--theme-secondary);
   outline: none;
 }
 blockquote {

--- a/assets/scss/_components.scss
+++ b/assets/scss/_components.scss
@@ -259,7 +259,7 @@
     flex-direction: column;
   }
   a {
-    color:var(--theme);
+    color: var(--theme-secondary);
     opacity: 0.8;
     transition: opacity 0.3s ease-in-out;
     &:hover {

--- a/assets/scss/_components.scss
+++ b/assets/scss/_components.scss
@@ -159,6 +159,17 @@
   }
 }
 
+.spoiler {
+  border: dashed var(--theme) 0.2rem;
+  border-radius: 1rem;
+  padding: 0.8rem;
+  margin-bottom: 1.2rem;
+
+  code {
+    white-space: pre;
+  }
+}
+
 .share {
   margin-left: 8px;
   position: relative;

--- a/assets/scss/_posts.scss
+++ b/assets/scss/_posts.scss
@@ -62,7 +62,7 @@
     margin-right: auto;
 
     a {
-      color: var(--theme);
+      color: var(--theme-secondary);
       transition: all 0.3s;
 
       &:hover {
@@ -138,7 +138,7 @@
 
     a {
       &:hover {
-        color: var(--theme);
+        color: var(--theme-secondary);
         text-decoration: underline;
         opacity: 0.9;
       }

--- a/assets/scss/_posts.scss
+++ b/assets/scss/_posts.scss
@@ -10,7 +10,11 @@
   h2 {
     position: relative;
     padding-right: 32px;
-    margin: 0.5rem auto;
+  }
+
+  h3, h4 {
+    text-align: left;
+    padding: 5px 0 0 0;
   }
 
   img:not(.icon) {
@@ -19,12 +23,6 @@
     height: auto;
     margin-left: auto;
     margin-right: auto;
-  }
-
-  h3, h4 {
-    margin: 0.5rem auto;
-    text-align: left;
-    padding: 5px 0 0 0;
   }
 
   p {
@@ -71,13 +69,12 @@
       }
     }
 
+    h1, h2, h3, h4 {
+      margin: 1.75rem auto 0.5rem auto;
+    }
+
     img:not(.icon) {
       margin-bottom: 2rem;
-
-      ~ h1, ~ h2, ~ h3, ~ h4 {
-        margin-top: 0;
-        padding-top: 0;
-      }
     }
   }
 

--- a/assets/scss/_syntax.scss
+++ b/assets/scss/_syntax.scss
@@ -137,7 +137,7 @@
 }
 
 .go {
-  color: #ccc;
+  color: unset;
 }
 
 .gp {

--- a/assets/scss/_variables.scss
+++ b/assets/scss/_variables.scss
@@ -8,5 +8,6 @@
   --bg: var(--light);
   --text: var(--dark);
   --font: 'Spartan', sans-serif;
-  --theme: #28537d 
+  --theme: #28537d;
+  --theme-secondary: #009ee3; /* corporate design color: blue secondary */ 
 }

--- a/layouts/shortcodes/spoiler.html
+++ b/layouts/shortcodes/spoiler.html
@@ -1,0 +1,13 @@
+<!--
+    Hugo shortcode used to create collapsable boxes with HTML content
+-->
+
+<details 
+    class="spoiler"
+    >
+
+    <summary>{{ .Get "title" }}</summary>
+
+    {{.Inner}}
+
+</details>


### PR DESCRIPTION
Improved the theme based on a  discussion with @neiser.

I checked multiple blogs posts. They all looked slightly better. ✅ 

Open points:
* [x] [These lines](https://github.com/qaware/qaware-blog-theme/compare/master...GollyTicker:qaware-blog-theme:master#diff-641f95e4bc8f21fa8b5e89c12a5e825dc271a733d9ff43ed2a78d53784d2af50L76-L80) were troubling, as they were resetting the header spacing even though we need them. I couldn't find any place where these were legitimately used, so I removed them. Do you know, what their intention was?
* [ ] After changing the styles, the [generated main.css is updated in the super repository](https://github.com/qaware/qaware-blog-source/pull/44/files#diff-6ffad7f7068dfb05c15df78957b398bfe04628b68225de63365c98d114bffa2d). However, for some reason, not all of my changes in the CSS are reflected there. Even more confusing is, that viewing the UI locally, the new styles still work correctly - despite the main.css not containing all new styles. For instance, the old anchor `color: var(--theme)` is still there: 🤔 
* [ ] Update super-repository submodule commit after merge
---

## Before with hacks

<kbd> <img src="https://user-images.githubusercontent.com/4527862/210543509-27b62be2-3d65-422d-bedb-fc83809899e8.png" /> </kbd>
and
<kbd> <img src="https://user-images.githubusercontent.com/4527862/210543515-b5a7b02b-8daa-4884-80c7-1e68087c52e4.png" /> </kbd>

---

## After without hacks

<kbd> <img src="https://user-images.githubusercontent.com/4527862/210541815-c599e693-72be-4c2a-8d26-4cfd2a20c10a.png" /> </kbd>

and

<kbd> <img src="https://user-images.githubusercontent.com/4527862/210541803-01797dfe-02d4-4507-a316-72c7c9e434fe.png" /> </kbd>

---

## Other blogpost: Before
![before](https://user-images.githubusercontent.com/4527862/210543924-b88d383a-5bb6-4ac4-bcb8-dfe87247b51b.png)

## Other blogpost: After
![after](https://user-images.githubusercontent.com/4527862/210543946-7cd4a01d-57ef-470e-ab8c-5adba553d2ce.png)
