### PR TITLE
Replace deprecated functions

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 {{- $pages := where site.RegularPages "Type" "in" site.Params.mainSections }}
 <div class = 'wrap pt-2 mt-3'>
-  {{- $size := .Paginator.PageSize }}
+  {{- $size := .Paginator.PagerSize }}
   {{- $scratch := newScratch }}
   {{- range $index, $value := (.Paginate $pages).Pages }}
     {{ if isset .Params "image" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -15,7 +15,7 @@
   {{- partial "favicon" . }}
   <link rel='canonical' href='{{ .Permalink }}'>
   {{- $options := (dict "targetPath" "css/main.css" "outputStyle" "expanded" "enableSourceMap" "true") -}}
-  {{- $styles := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | resources.ToCSS $options | resources.Fingerprint "sha512" }}
+  {{- $styles := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate "scss/main.scss" . | toCSS $options | resources.Fingerprint "sha512" }}
   <link rel = 'stylesheet' href = '{{ $styles.Permalink }}' integrity = '{{ $styles.Data.Integrity }}' title="templateStyle">
 
   {{ with .OutputFormats.Get "rss" -}}


### PR DESCRIPTION
```
WARN  deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in a future release. Use css.Sass instead.
WARN  deprecated: PageSize was deprecated in Hugo v0.128.0 and will be removed in a future release. Use PagerSize instead.
```

Lokal klappen die Changes.